### PR TITLE
Add github action to update homebrew

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -16,3 +16,13 @@ action "Upload to release" {
   secrets = ["GITHUB_TOKEN"]
   needs = ["Build Release"]
 }
+
+workflow "Update Homebrew" {
+  on = "release"
+  resolves = ["Action Homebrew"]
+}
+
+action "Action Homebrew" {
+  uses = "./action-homebrew/"
+  secrets = ["HOMEBREW_GITHUB_TOKEN"]
+}

--- a/action-homebrew/Dockerfile
+++ b/action-homebrew/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.9
+
+LABEL "com.github.actions.name"="Update Homebrew"
+LABEL "com.github.actions.description"="Updates homebrew binary hash and version number"
+LABEL "com.github.actions.icon"="package"
+LABEL "com.github.actions.color"="purple"
+
+LABEL "maintainer"="Diego Cabrejas <diego@wearejh.com>"
+
+RUN apk add --no-cache git
+RUN apk add --no-cache openssh
+RUN apk add --no-cache curl
+RUN apk add --no-cache perl-utils
+
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action-homebrew/README.md
+++ b/action-homebrew/README.md
@@ -1,0 +1,5 @@
+## Update Homebrew
+
+This Action updates the homebrew repository with the latest binary hash and version number.
+
+This is meant to be run upon creating new releases.

--- a/action-homebrew/entrypoint.sh
+++ b/action-homebrew/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+#declare variables
+binaryUrl="https://github.com/WeareJH/wf2/releases/latest/download/wf2"
+githubToken=$HOMEBREW_GITHUB_TOKEN
+
+#setup git user
+git config --global user.name "wf2 bot"
+git config --global user.email "wf2@wearejh.com"
+
+#download binary
+echo "Downloading Binary file from $binaryUrl"
+curl -s -o /binary $binaryUrl
+
+#store hash
+hash=$(shasum -a 256 /binary | awk '{print $1}')
+echo "Binary hash is : $hash"
+
+#store github fingerprint so that we can clone without interaction
+mkdir ~/.ssh && touch ~/.ssh/known_hosts
+ssh-keyscan github.com 2> /dev/null >> ~/.ssh/known_hosts
+
+#store latest tag name
+echo "Cloning wf2 repo..."
+rm -rf wf2 && git clone --quiet https://$githubToken@github.com/WeareJH/wf2.git
+cd wf2
+tagName=$(git describe --tags `git rev-list --tags --max-count=1`)
+cd /
+echo "Latest tag is : $tagName"
+
+#clone homebrew tools repository
+echo "Cloning homebrew-tools repo..."
+rm -rf homebrew-tools && git clone --quiet https://$githubToken@github.com/WeareJH/homebrew-tools.git
+cd homebrew-tools
+
+#update hash and version number
+echo "Updating hash and tag name..."
+sed -i "s/sha256.*/sha256 '$hash'/g" wf2.rb
+sed -i "s/version.*/version '$tagName'/g" wf2.rb
+
+#commit and force push to homebrew repo
+echo "Adding commit and pushing..."
+git add wf2.rb
+git commit -m "update hash to $hash"
+git push --force
+
+echo "Done!"


### PR DESCRIPTION
Added a new GitHub action to automatically update the homebrew tools repo when a new release is created. It updates the hash and the version number in homebrew.