### PR TITLE
increase nginx body size to 20M

### DIFF
--- a/wf2_core/src/recipes/m2/templates/site.conf
+++ b/wf2_core/src/recipes/m2/templates/site.conf
@@ -19,6 +19,7 @@ server {
     charset UTF-8;
     error_page 404 403 = /errors/404.php;
     #add_header "X-UA-Compatible" "IE=Edge";
+    client_max_body_size 20M;    
 
     set $BACKEND fastcgi_backend;
     if ($arg_debug) {


### PR DESCRIPTION
Trend project has an endpoint which takes a CSV file and validates it. This is part of the integration with a 3rd party. Default nginx limit was too low, I think other projects could benefit too from having this limit increased in our development machines to avoid people hitting it. 