### PR TITLE
Added an express install option

### DIFF
--- a/express-install.sh
+++ b/express-install.sh
@@ -65,6 +65,7 @@ if [[ $continueInstall == "y" ]] ; then
 			    echo " - this will delete your existing installation (y/n) "
 				read reinstall
 				if [[ $reinstall == "y" ]] ; then
+						rm $(which wf2)
 						exec_install
 				else
 						aborting_install

--- a/express-install.sh
+++ b/express-install.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#set -x #uncomment for debug mode
+
+clear_term() {
+	#comment out for output
+	clear 
+	#echo "debug -- clear"
+}
+
+aborting_install() {
+	clear_term
+	echo "Aborting Install"
+}
+
+path_check() {
+	path_check_var=$(which wf2)
+	if [ -x "$path_check_var" ] ; then
+			echo "WF2 appears to be in your path! Continuing..."
+			sleep 2
+	else 
+			echo "WF2 does not appear to be in your path,"
+			echo "Would you like the installer to try to auto add WF2 to your path? (y/n) "
+			read addToPath
+			if [[ $addToPath == "y" ]] ; then
+					touch ~/.zshrc
+					echo "export PATH=\"$PATH:/opt\"" >> ~/.zshrc
+					echo "Now we are going to refresh your terminal"
+					sleep 2
+					source ~/.zshrc
+			else
+					echo "Skipping add to path step"
+			fi
+	fi
+}
+
+exec_install() {
+	clear_term
+	echo "Beginning express download of WF2"
+	curl -L "https://github.com/wearejh/wf2/releases/download/v0.18.0/wf2" --output wf2-temp-binary-file
+	chmod +x ./wf2-temp-binary-file
+	echo "Download successful!"
+	echo "You may now be asked for your password to install the WF2 binary"
+	sudo mkdir -p /opt
+	sudo chown -R $(whoami) /opt
+	mv ./wf2-temp-binary-file /opt/wf2
+	path_check
+	echo "Now the self-update function will run to get the latest version!"
+	sleep 2
+	wf2 self-update
+	echo "Thank you for using the express installer!"
+	echo "(You may need to run \"source ~/.zshrc\" - without the quotes - to see wf2)"
+}
+
+clear_term
+echo "Welcome to the WF2 Express installer!"
+echo "Would you like to install WF2? (y/n) "
+read continueInstall
+if [[ $continueInstall == "y" ]] ; then
+		echo "Ok, installing now"
+		path_to_executable=$(which wf2)
+		if [ -x "$path_to_executable" ] ; then
+				clear_term
+				echo "Looks like wf2 is already installed"
+				echo "Would you like to reinstall?"
+			    echo " - this will delete your existing installation (y/n) "
+				read reinstall
+				if [[ $reinstall == "y" ]] ; then
+						exec_install
+				else
+						aborting_install
+				fi
+		else
+				exec_install
+		fi
+else
+		aborting_install
+fi
+

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,12 @@
 # wf2 [![Build Status](https://travis-ci.org/WeareJH/wf2.svg?branch=master)](https://travis-ci.org/WeareJH/wf2)
 
+## Express Install
+
+Simply run the following in your terminal
+
+```
+zsh <(curl -L https://raw.githubusercontent.com/WeareJH/wf2/bash-installer/express-install.sh) && source ~/.zshrc
+```
 
 ## Install
 `wf2` is distributed as a single binary with everything packaged inside -

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 Simply run the following in your terminal
 
 ```
-zsh <(curl -L https://raw.githubusercontent.com/WeareJH/wf2/bash-installer/express-install.sh) && source ~/.zshrc
+zsh <(curl -L https://raw.githubusercontent.com/WeareJH/wf2/master/express-install.sh) && source ~/.zshrc
 ```
 
 ## Install


### PR DESCRIPTION
Added a bash script for people to use that will automate the process of installing the wf2 binary initially.

It handles:

- Downloading the binary to disk and setting the +x permission
- Moving the binary into the `/opt` folder
- Will add to the user's path if not already
- Runs wf2 self-update at the end to fetch the latest version (it is currently hardcoded to download version 0.18 - the first release with the update command)