### PR TITLE
Automate GH release asset

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,8 +23,11 @@ jobs:
                   args: --target x86_64-apple-darwin --release
 
             - name: Release
-              uses: JasonEtco/upload-to-release@master
-              with:
-                  args: target/x86_64-apple-darwin/release/wf2 application/octet-stream
+            - uses: actions/upload-release-asset@v1.0.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  upload_url: ${{ github.url }}
+                  asset_path: target/x86_64-apple-darwin/release/wf2
+                  asset_name: wf2
+                  asset_content_type: application/octet-stream


### PR DESCRIPTION
Use a different upload release asset action as the current one doesn't work on macOS builds 😢 