### PR TITLE
Update site.conf

### DIFF
--- a/wf2_core/src/recipes/m2/templates/site.conf
+++ b/wf2_core/src/recipes/m2/templates/site.conf
@@ -67,7 +67,8 @@ server {
         location ~ (index|get|static|report|404|503|health_check)\.php$ {
             try_files $uri =404;
             fastcgi_pass   $BACKEND;
-            fastcgi_buffers 1024 4k;
+            fastcgi_buffers 16 16k;
+            fastcgi_buffer_size 32k;
 
             fastcgi_read_timeout 600s;
             fastcgi_connect_timeout 600s;
@@ -161,7 +162,8 @@ server {
     location ~ (index|get|static|report|404|503|health_check)\.php$ {
         try_files $uri =404;
         fastcgi_pass   $BACKEND;
-        fastcgi_buffers 1024 4k;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
 
         fastcgi_read_timeout 600s;
         fastcgi_connect_timeout 600s;


### PR DESCRIPTION
**Issue:** certain categories (Specifically G&G & BSO) were failing to load with a 502 response. I was provided with the log:

`wf2__graham-and-green__nginx | 2020/01/07 15:42:18 [error] 7#7: *3043 upstream sent too big header while reading response header from upstream, client: 172.20.0.12, server: , request: "GET /sofas HTTP/1.1", upstream: "fastcgi://172.20.0.9:9000", host: "gg.m2"` 

After googling I found a solution that solved the problem and tested by overriding the `site.conf` locally.

@mikeymike Checked and approved of solution.