### PR TITLE
Only stop and rm containers, if there are some running

### DIFF
--- a/wf2_core/src/recipes/m2/subcommands/up.rs
+++ b/wf2_core/src/recipes/m2/subcommands/up.rs
@@ -51,8 +51,8 @@
 //! #   .with_file("../fixtures/config_01.yaml")
 //! #   .file_ops_paths_commands();
 //! # assert_eq!(commands, vec![
-//! #     "docker stop $(docker ps -aq)",
-//! #     "docker rm $(docker ps -aq)",
+//! #     "if [[ $(docker ps -aq) ]]; then docker stop $(docker ps -aq); fi",
+//! #     "if [[ $(docker ps -aq) ]]; then docker rm $(docker ps -aq); fi",
 //! #     "docker-compose -f /users/shane/.wf2_m2_shane/docker-compose.yml up -d"
 //! # ]);
 //! ```

--- a/wf2_core/src/tasks/docker_clean.rs
+++ b/wf2_core/src/tasks/docker_clean.rs
@@ -2,7 +2,7 @@ use crate::task::Task;
 
 pub fn docker_clean() -> Vec<Task> {
     vec![
-        Task::simple_command("docker stop $(docker ps -aq)"),
-        Task::simple_command("docker rm $(docker ps -aq)"),
+        Task::simple_command("if [[ $(docker ps -aq) ]]; then docker stop $(docker ps -aq); fi"),
+        Task::simple_command("if [[ $(docker ps -aq) ]]; then docker rm $(docker ps -aq); fi"),
     ]
 }


### PR DESCRIPTION
Before this patch, with no containers running:

```
wf2 up --clean
[wf2 info]: using config file wf2.yml
"docker stop" requires at least 1 argument.
See 'docker stop --help'.

Usage:  docker stop [OPTIONS] CONTAINER [CONTAINER...]

Stop one or more running containers
```