### PR TITLE
Add n98 passthru

### DIFF
--- a/wf2_core/src/recipes/m2/pass_thru.rs
+++ b/wf2_core/src/recipes/m2/pass_thru.rs
@@ -16,7 +16,7 @@ pub enum M2PassThru {
     Dc,
     Node,
     M,
-    N98
+    N98,
 }
 
 impl M2PassThru {
@@ -38,7 +38,7 @@ impl M2PassThru {
             M2PassThru::Dc => M2PassThru::DC,
             M2PassThru::Node => M2PassThru::NODE,
             M2PassThru::M => M2PassThru::MAGE,
-            M2PassThru::N98 => M2PassThru::N98_MAGERUN
+            M2PassThru::N98 => M2PassThru::N98_MAGERUN,
         }
         .to_string()
     }

--- a/wf2_core/src/recipes/m2/pass_thru.rs
+++ b/wf2_core/src/recipes/m2/pass_thru.rs
@@ -1,6 +1,7 @@
 use crate::recipes::m2::subcommands::composer::{composer, ComposerPassThru};
 use crate::recipes::m2::subcommands::dc::{dc_passthru, DcPassThru};
 use crate::recipes::m2::subcommands::m::{mage, MPassThru};
+use crate::recipes::m2::subcommands::n98::{n98, N98PassThru};
 use crate::recipes::m2::subcommands::node::{node, NodePassThru};
 use crate::recipes::m2::M2Recipe;
 use crate::{context::Context, task::Task};
@@ -15,6 +16,7 @@ pub enum M2PassThru {
     Dc,
     Node,
     M,
+    N98
 }
 
 impl M2PassThru {
@@ -25,6 +27,7 @@ impl M2PassThru {
     const DC: &'static str = "dc";
     const NODE: &'static str = "node";
     const MAGE: &'static str = "m";
+    const N98_MAGERUN: &'static str = "n98";
 
     ///
     /// Helper method for converting an enum member to a String
@@ -35,6 +38,7 @@ impl M2PassThru {
             M2PassThru::Dc => M2PassThru::DC,
             M2PassThru::Node => M2PassThru::NODE,
             M2PassThru::M => M2PassThru::MAGE,
+            M2PassThru::N98 => M2PassThru::N98_MAGERUN
         }
         .to_string()
     }
@@ -45,6 +49,7 @@ impl M2PassThru {
                 ref x if *x == M2PassThru::Node => Some(node(trailing, dc)),
                 ref x if *x == M2PassThru::Composer => Some(composer(&ctx, trailing)),
                 ref x if *x == M2PassThru::M => Some(mage(&ctx, trailing)),
+                ref x if *x == M2PassThru::N98 => Some(n98(&ctx, trailing)),
                 _ => None,
             },
             Err(e) => Some(Task::task_err_vec(e)),
@@ -58,6 +63,7 @@ pub fn commands() -> Vec<(String, String)> {
         (M2PassThru::Dc, DcPassThru::ABOUT),
         (M2PassThru::Node, NodePassThru::ABOUT),
         (M2PassThru::M, MPassThru::ABOUT),
+        (M2PassThru::N98, N98PassThru::ABOUT),
     ]
     .into_iter()
     .map(|(name, help)| (name.into(), help.into()))

--- a/wf2_core/src/recipes/m2/subcommands/mod.rs
+++ b/wf2_core/src/recipes/m2/subcommands/mod.rs
@@ -34,6 +34,7 @@ pub mod m2_playground;
 pub mod m2_playground_cmd;
 #[doc(hidden)]
 pub mod m2_playground_help;
+pub mod n98;
 pub mod node;
 pub mod pull;
 pub mod push;
@@ -45,7 +46,6 @@ pub mod up_help;
 pub mod update_images;
 pub mod varnish;
 pub mod xdebug;
-pub mod n98;
 
 pub fn m2_recipe_subcommands<'a, 'b>() -> Vec<Box<dyn CliCommand<'a, 'b>>> {
     vec![

--- a/wf2_core/src/recipes/m2/subcommands/mod.rs
+++ b/wf2_core/src/recipes/m2/subcommands/mod.rs
@@ -45,6 +45,7 @@ pub mod up_help;
 pub mod update_images;
 pub mod varnish;
 pub mod xdebug;
+pub mod n98;
 
 pub fn m2_recipe_subcommands<'a, 'b>() -> Vec<Box<dyn CliCommand<'a, 'b>>> {
     vec![

--- a/wf2_core/src/recipes/m2/subcommands/n98.rs
+++ b/wf2_core/src/recipes/m2/subcommands/n98.rs
@@ -1,0 +1,29 @@
+
+use crate::context::Context;
+use crate::recipes::m2::services::php::PhpService;
+use crate::task::Task;
+
+pub struct N98PassThru;
+
+impl N98PassThru {
+    pub const ABOUT: &'static str = "[m2] Execute n98-magerun2 commands inside the PHP container";
+}
+
+pub fn n98(ctx: &Context, trailing: Vec<String>) -> Vec<Task> {
+    PhpService::select(&ctx)
+        .map(|service| {
+            let full_command = format!(
+                r#"docker exec -it -u www-data -e COLUMNS="{width}" -e LINES="{height}" {container_name} n98-magerun2 {trailing_args}"#,
+                width = ctx.term.width,
+                height = ctx.term.height,
+                container_name = service.container_name,
+                trailing_args = trailing
+                    .into_iter()
+                    .skip(1)
+                    .collect::<Vec<String>>()
+                    .join(" ")
+            );
+            vec![Task::simple_command(full_command)]
+        })
+        .unwrap_or_else(Task::task_err_vec)
+}

--- a/wf2_core/src/recipes/m2/subcommands/n98.rs
+++ b/wf2_core/src/recipes/m2/subcommands/n98.rs
@@ -1,4 +1,3 @@
-
 use crate::context::Context;
 use crate::recipes::m2::services::php::PhpService;
 use crate::task::Task;


### PR DESCRIPTION
Adds n98 passthrough to the php container within the Magento 2 Recipe.
Link: https://github.com/netz98/n98-magerun2
