### PR TITLE
MVP: Upgrade to Traefik v2

### DIFF
--- a/wf2_core/src/recipes/m2/output_files/mod.rs
+++ b/wf2_core/src/recipes/m2/output_files/mod.rs
@@ -11,7 +11,7 @@ use m2_runtime_env_file::M2RuntimeEnvFile;
 use nginx_m2::NginxM2;
 use nginx_pwa::NginxPwa;
 use nginx_upstream::NginxUpstream;
-use traefik::{TraefikFile,TraefikRedirectFile};
+use traefik::{TraefikFile, TraefikRedirectFile};
 use unison::UnisonFile;
 
 pub mod auth;

--- a/wf2_core/src/recipes/m2/output_files/mod.rs
+++ b/wf2_core/src/recipes/m2/output_files/mod.rs
@@ -11,7 +11,7 @@ use m2_runtime_env_file::M2RuntimeEnvFile;
 use nginx_m2::NginxM2;
 use nginx_pwa::NginxPwa;
 use nginx_upstream::NginxUpstream;
-use traefik::TraefikFile;
+use traefik::{TraefikFile,TraefikRedirectFile};
 use unison::UnisonFile;
 
 pub mod auth;
@@ -32,6 +32,7 @@ impl OutputFiles for M2Recipe {
             M2RuntimeEnvFile::from_ctx(&ctx)?.write_task(),
             UnisonFile::from_ctx(&ctx)?.write_task(),
             TraefikFile::from_ctx(&ctx)?.write_task(),
+            TraefikRedirectFile::from_ctx(&ctx)?.write_task(),
             NginxUpstream::from_ctx(&ctx)?.write_task(),
             NginxM2::from_ctx(&ctx)?.write_task(),
             DbConf::from_ctx(&ctx)?.write_task(),

--- a/wf2_core/src/recipes/m2/output_files/traefik.rs
+++ b/wf2_core/src/recipes/m2/output_files/traefik.rs
@@ -22,6 +22,30 @@ impl File<TraefikFile> for TraefikFile {
     }
 
     fn bytes(&self) -> Vec<u8> {
-        include_bytes!("./traefik.toml").to_vec()
+        include_bytes!("traefik.toml").to_vec()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TraefikRedirectFile {
+    file_path: PathBuf,
+}
+
+impl File<TraefikRedirectFile> for TraefikRedirectFile {
+    const DESCRIPTION: &'static str = "Writes the traefik redirect file";
+    const HOST_OUTPUT_PATH: &'static str = "traefik/dynamic/redirect.toml";
+
+    fn from_ctx(ctx: &Context) -> Result<TraefikRedirectFile, failure::Error> {
+        Ok(TraefikRedirectFile {
+            file_path: ctx.output_file_path(Self::HOST_OUTPUT_PATH),
+        })
+    }
+
+    fn file_path(&self) -> PathBuf {
+        self.file_path.clone()
+    }
+
+    fn bytes(&self) -> Vec<u8> {
+        include_bytes!("traefik/redirect.toml").to_vec()
     }
 }

--- a/wf2_core/src/recipes/m2/output_files/traefik.toml
+++ b/wf2_core/src/recipes/m2/output_files/traefik.toml
@@ -1,21 +1,23 @@
-debug = true
+[global]
+  sendAnonymousUsage = false
 
-logLevel = "DEBUG"
-defaultEntryPoints = ["https","http"]
+[log]
+  level = "DEBUG" 
+  format = "common"
 
 [entryPoints]
   [entryPoints.http]
-  address = ":80"
-    [entryPoints.http.redirect]
-    entryPoint = "https"
+    address = ":80"
   [entryPoints.https]
-  address = ":443"
-  [entryPoints.https.tls]
+    address = ":443"
+    
+[api]
+  insecure = true
+  dashboard = true
 
-[retry]
-
-[docker]
-endpoint = "unix:///var/run/docker.sock"
-domain = "traefik.local"
-watch = true
-exposedByDefault = false
+[providers]
+  [providers.docker]
+  endpoint = "unix:///var/run/docker.sock"
+  [providers.file]
+  directory = "/etc/traefik/dynamic"
+  watch = true

--- a/wf2_core/src/recipes/m2/output_files/traefik/redirect.toml
+++ b/wf2_core/src/recipes/m2/output_files/traefik/redirect.toml
@@ -1,0 +1,16 @@
+[http.services.DefaultHTTPSRedirect.loadBalancer]
+  [[http.services.DefaultHTTPSRedirect.loadBalancer.servers]]
+    url = "http://localhost/"
+
+# router with PathPrefix /, so everything will be matched
+[http.routers.DefaultHTTPSRedirect]
+  entryPoints = [ "http" ]
+  rule = "PathPrefix(`/`)"
+  middlewares = [ "DefaultHTTPSRedirect" ]
+  service = "DefaultHTTPSRedirect"
+  # lowest possible priority so that the match can be overwritten by anyone
+  priority = 1
+
+[http.middlewares.DefaultHTTPSRedirect.RedirectScheme]
+  scheme = "https"
+  permanent = true

--- a/wf2_core/src/recipes/m2/subcommands/up.rs
+++ b/wf2_core/src/recipes/m2/subcommands/up.rs
@@ -21,6 +21,7 @@
 //! #         "/users/shane/.wf2_m2_shane/.docker.env",
 //! #         "/users/shane/.wf2_m2_shane/unison/conf/sync.prf",
 //! #         "/users/shane/.wf2_m2_shane/traefik/traefik.toml",
+//! #         "/users/shane/.wf2_m2_shane/traefik/dynamic/redirect.toml",
 //! #         "/users/shane/.wf2_m2_shane/nginx/sites/upstream.conf",
 //! #         "/users/shane/.wf2_m2_shane/nginx/sites/site.conf",
 //! #         "/users/shane/.wf2_m2_shane/mysql/mysqlconf/mysql.cnf",

--- a/wf2_core/src/services/mail.rs
+++ b/wf2_core/src/services/mail.rs
@@ -23,7 +23,7 @@ impl Service for MailService {
 
     fn dc_service(&self, ctx: &Context, _: &()) -> DcService {
         let traefik_label =
-            TraefikService::simple_entry(MailService::NAME, MailService::DOMAIN, true, 8025_u32);
+            TraefikService::route_to_svc(MailService::NAME, vec![MailService::DOMAIN.into()],true, 8025);
         DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
             .set_ports(vec!["1025"])
             .set_labels(traefik_label)

--- a/wf2_core/src/services/mail.rs
+++ b/wf2_core/src/services/mail.rs
@@ -22,12 +22,11 @@ impl Service for MailService {
     const IMAGE: &'static str = "mailhog/mailhog";
 
     fn dc_service(&self, ctx: &Context, _: &()) -> DcService {
+        let traefik_label =
+            TraefikService::simple_entry(MailService::NAME, MailService::DOMAIN, true, 8025_u32);
         DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
             .set_ports(vec!["1025"])
-            .set_labels(TraefikService::host_entry_label(
-                MailService::DOMAIN,
-                8025_u32,
-            ))
+            .set_labels(traefik_label)
             .finish()
     }
 }

--- a/wf2_core/src/services/mail.rs
+++ b/wf2_core/src/services/mail.rs
@@ -22,8 +22,12 @@ impl Service for MailService {
     const IMAGE: &'static str = "mailhog/mailhog";
 
     fn dc_service(&self, ctx: &Context, _: &()) -> DcService {
-        let traefik_label =
-            TraefikService::route_to_svc(MailService::NAME, vec![MailService::DOMAIN.into()],true, 8025);
+        let traefik_label = TraefikService::route_to_svc(
+            MailService::NAME,
+            vec![MailService::DOMAIN.into()],
+            true,
+            8025,
+        );
         DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
             .set_ports(vec!["1025"])
             .set_labels(traefik_label)

--- a/wf2_core/src/services/rabbit_mq.rs
+++ b/wf2_core/src/services/rabbit_mq.rs
@@ -8,8 +8,8 @@ pub struct RabbitMqService;
 
 impl RabbitMqService {
     pub const DOMAIN: &'static str = "queue.jh";
-    pub const PORT_PUBLIC: u32 = 15672;
-    pub const PORT_INTERNAL: u32 = 5672;
+    pub const PORT_PUBLIC: u16 = 15672;
+    pub const PORT_INTERNAL: u16 = 5672;
 }
 
 impl fmt::Display for RabbitMqService {
@@ -32,9 +32,9 @@ impl Service for RabbitMqService {
                 format!("{port}:{port}", port = RabbitMqService::PORT_PUBLIC),
                 format!("{port}:{port}", port = RabbitMqService::PORT_INTERNAL),
             ])
-            .set_labels(TraefikService::simple_entry(
+            .set_labels(TraefikService::route_to_svc(
                 RabbitMqService::NAME,
-                RabbitMqService::DOMAIN,
+                vec![RabbitMqService::DOMAIN.into()],
                 false,
                 RabbitMqService::PORT_PUBLIC,
             ))

--- a/wf2_core/src/services/rabbit_mq.rs
+++ b/wf2_core/src/services/rabbit_mq.rs
@@ -32,8 +32,10 @@ impl Service for RabbitMqService {
                 format!("{port}:{port}", port = RabbitMqService::PORT_PUBLIC),
                 format!("{port}:{port}", port = RabbitMqService::PORT_INTERNAL),
             ])
-            .set_labels(TraefikService::host_entry_label(
+            .set_labels(TraefikService::simple_entry(
+                RabbitMqService::NAME,
                 RabbitMqService::DOMAIN,
+                false,
                 RabbitMqService::PORT_PUBLIC,
             ))
             .finish()

--- a/wf2_core/src/services/traefik.rs
+++ b/wf2_core/src/services/traefik.rs
@@ -75,15 +75,15 @@ mod test {
 
     #[test]
     fn test_host_entry() {
-        let labels = TraefikService::route_to_svc("mailhog", "mail.jh", true, 8080_u32);
+        let labels = TraefikService::route_to_svc("mailhog", vec!["mail.jh".into()], true, 8080);
         assert_eq!(
             labels,
             vec![
-                "traefik.http.routers.mailhog.rule=Host(`mail.jh`)",
-                "traefik.http.routers.mailhog.service=mailhog-svc",
-                "traefik.http.routers.mailhog.tls=true",
-                "traefik.http.services.mailhog-svc.loadBalancer.server.port=8080",
-                "traefik.enable=true"
+                "traefik.http.routers.mail-jh.rule=Host(`mail.jh`)",
+                "traefik.http.routers.mail-jh.service=mailhog_svc",
+                "traefik.http.routers.mail-jh.tls=true",
+                "traefik.enable=true",
+                "traefik.http.services.mailhog_svc.loadBalancer.server.port=8080"
             ]
         )
     }
@@ -96,17 +96,17 @@ mod test {
 
             name: "traefik"
             container_name: wf2__wf2_default__traefik
-            image: "traefik:1.7"
+            image: "traefik:2.2"
             volumes:
               - "/var/run/docker.sock:/var/run/docker.sock"
               - "./.wf2_default/traefik/traefik.toml:/etc/traefik/traefik.toml"
+              - "./.wf2_default/traefik/dynamic/redirect.toml:/etc/traefik/dynamic/redirect.toml"
             labels:
               - traefik.enable=false
             ports:
               - "80:80"
               - "443:443"
               - "8080:8080"
-            command: "--api --docker"
             networks:
               default:
                 aliases:

--- a/wf2_core/src/services/varnish.rs
+++ b/wf2_core/src/services/varnish.rs
@@ -51,11 +51,14 @@ mod tests {
             container_name: wf2__wf2_default__varnish
             image: "wearejh/varnish:latest"
             labels:
-              - "traefik.frontend.rule=Host:local.m2"
+              - "traefik.http.routers.local-m2.rule=Host(`local.m2`)"
+              - "traefik.http.routers.local-m2.service=varnish_svc"
+              - "traefik.http.routers.local-m2.tls=true"
+              - "traefik.enable=true"
+              - "traefik.http.services.varnish_svc.loadBalancer.server.port=80"
             depends_on:
               - nginx
               - php
-
         "#;
         let expected_dc: DcService = serde_yaml::from_str(expected).expect("test yaml");
         assert_eq!(actual_dc, expected_dc);
@@ -73,7 +76,17 @@ mod tests {
             container_name: wf2__wf2_default__varnish
             image: "wearejh/varnish:latest"
             labels:
-              - "traefik.frontend.rule=Host:example.m2,example.pwa,test.ngrok.io"
+              - "traefik.http.routers.example-m2.rule=Host(`example.m2`)"
+              - "traefik.http.routers.example-m2.service=varnish_svc"
+              - "traefik.http.routers.example-m2.tls=true"
+              - "traefik.http.routers.example-pwa.rule=Host(`example.pwa`)"
+              - "traefik.http.routers.example-pwa.service=varnish_svc"
+              - "traefik.http.routers.example-pwa.tls=true"
+              - "traefik.http.routers.test-ngrok-io.rule=Host(`test.ngrok.io`)"
+              - "traefik.http.routers.test-ngrok-io.service=varnish_svc"
+              - "traefik.http.routers.test-ngrok-io.tls=true"
+              - "traefik.enable=true"
+              - "traefik.http.services.varnish_svc.loadBalancer.server.port=80"
             depends_on:
               - nginx
               - php

--- a/wf2_core/src/services/varnish.rs
+++ b/wf2_core/src/services/varnish.rs
@@ -26,12 +26,11 @@ impl Service for VarnishService {
         DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
             .set_depends_on(depends_on)
             .set_labels(TraefikService::route_to_svc(
-                    Self::NAME,
-                    base_domains,
-                    true,
-                    80,
-                    )
-                )
+                Self::NAME,
+                base_domains,
+                true,
+                80,
+            ))
             .finish()
     }
 }

--- a/wf2_core/src/services/varnish.rs
+++ b/wf2_core/src/services/varnish.rs
@@ -25,11 +25,11 @@ impl Service for VarnishService {
 
         DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
             .set_depends_on(depends_on)
-            .set_labels(TraefikService::simple_entry(
+            .set_labels(TraefikService::route_to_svc(
                     Self::NAME,
-                    base_domains.join(","),
+                    base_domains,
                     true,
-                    80_u32,
+                    80,
                     )
                 )
             .finish()

--- a/wf2_core/src/services/varnish.rs
+++ b/wf2_core/src/services/varnish.rs
@@ -25,9 +25,13 @@ impl Service for VarnishService {
 
         DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
             .set_depends_on(depends_on)
-            .set_labels(TraefikService::host_only_entry_label(
-                base_domains.join(","),
-            ))
+            .set_labels(TraefikService::simple_entry(
+                    Self::NAME,
+                    base_domains.join(","),
+                    true,
+                    80_u32,
+                    )
+                )
             .finish()
     }
 }


### PR DESCRIPTION
MVP upgrade to traefik V2

V1 -> V2 Migration documentation can be found: [here](https://docs.traefik.io/migration/v1-to-v2/)

Clippy is currently failing, some are simple fixes but whether it should be addressed in this PR or outside.

TODO: 
- [x]  add http -> https redirect.
- [x] fix unit test


