### PR TITLE
Increase php memory limit

### DIFF
--- a/wf2_core/src/recipes/m2/m2_runtime_env_file.rs
+++ b/wf2_core/src/recipes/m2/m2_runtime_env_file.rs
@@ -65,7 +65,7 @@ env_vars! {
     MYSQL_TEST_PASSWORD="docker"
     MYSQL_TEST_DATABASE="docker_test"
 
-    PHP_MEMORY_LIMIT="2G"
+    PHP_MEMORY_LIMIT="4G"
 
     RABBITMQ_DEFAULT_USER="docker"
     RABBITMQ_DEFAULT_PASS="docker"


### PR DESCRIPTION
2G isn't enough on a few projects when updating dependencies