### PR TITLE
Lock down mysql auth method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2183,7 +2183,7 @@ checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wf2"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "ansi_term",
  "clap",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "wf2_core"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "ansi_term",
  "base64 0.11.0",

--- a/wf2/Cargo.toml
+++ b/wf2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf2"
-version = "0.33.1"
+version = "0.33.2"
 authors = ["Shane Osbourne <shane.osbourne8@gmail.com>"]
 edition = "2018"
 description = "PHP docker environments"
@@ -9,7 +9,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wf2_core = { path = "../wf2_core", version = "0.33.1" }
+wf2_core = { path = "../wf2_core", version = "0.33.2" }
 tokio = "0.1.20"
 futures = "0.1.27"
 clap = { version = "2.33.0", features = ["yaml"] }

--- a/wf2_core/Cargo.toml
+++ b/wf2_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wf2_core"
-version = "0.33.1"
+version = "0.33.2"
 authors = ["Shane Osbourne <shane.osbourne8@gmail.com>"]
 edition = "2018"
 description = "The engine for WF2"

--- a/wf2_core/src/recipes/m2/services/db.rs
+++ b/wf2_core/src/recipes/m2/services/db.rs
@@ -72,6 +72,7 @@ impl Service<M2Vars> for DbService {
                     DbService::VOLUME_ENTRY
                 ),
             ])
+            .set_command("--default-authentication-plugin=mysql_native_password")
             .set_ports(vec!["3306:3306"])
             .set_restart("unless-stopped")
             .set_env_file(vec![vars.content[&M2Var::EnvFile].to_string()])
@@ -120,7 +121,7 @@ mod tests {
               - traefik.enable=false
             ports:
               - "3306:3306"
-
+            command: "--default-authentication-plugin=mysql_native_password"
 
         "#;
         let expected_dc: DcService = serde_yaml::from_str(expected).expect("test yaml");


### PR DESCRIPTION
From MySQL8, the default method of authentication has changed from "mysql_native_password" to "caching_sha2_password". Unfortunately PHP7.3 isn't compatible with this new authentication method.

In order to have any version of PHP be compatible with any version of MySQL, I've locked the auth method to be the "mysql_native_password". 