### PR TITLE
Add support for multiple elasticsearch versions

### DIFF
--- a/wf2_core/src/context.rs
+++ b/wf2_core/src/context.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use std::{fmt, fs};
+use crate::versions::elasticsearch::ELASTICSEARCH;
 
 pub const DEFAULT_DOMAIN: &str = "local.m2";
 
@@ -79,6 +80,12 @@ pub struct Context {
         deserialize_with = "crate::php::deserialize_php"
     )]
     pub php_version: PHP,
+    #[serde(
+    skip_serializing,
+    default,
+    deserialize_with = "crate::versions::elasticsearch::deserialize_elasticsearch"
+    )]
+    pub es_version: crate::versions::elasticsearch::ELASTICSEARCH,
 
     #[serde(skip_serializing, default)]
     pub config_path: Option<PathBuf>,
@@ -167,6 +174,7 @@ impl Default for Context {
             pv: None,
             npm_path: default_cwd(),
             php_version: PHP::SevenThree,
+            es_version: ELASTICSEARCH::SevenSix,
             config_path: None,
             config_env_path: None,
             overrides: None,

--- a/wf2_core/src/context.rs
+++ b/wf2_core/src/context.rs
@@ -7,9 +7,9 @@ use from_file::{FromFile, FromFileError};
 use serde_yaml::Value;
 use std::path::PathBuf;
 
+use crate::versions::elasticsearch::ELASTICSEARCH;
 use serde::Deserialize;
 use std::{fmt, fs};
-use crate::versions::elasticsearch::ELASTICSEARCH;
 
 pub const DEFAULT_DOMAIN: &str = "local.m2";
 
@@ -81,9 +81,9 @@ pub struct Context {
     )]
     pub php_version: PHP,
     #[serde(
-    skip_serializing,
-    default,
-    deserialize_with = "crate::versions::elasticsearch::deserialize_elasticsearch"
+        skip_serializing,
+        default,
+        deserialize_with = "crate::versions::elasticsearch::deserialize_elasticsearch"
     )]
     pub es_version: crate::versions::elasticsearch::ELASTICSEARCH,
 

--- a/wf2_core/src/lib.rs
+++ b/wf2_core/src/lib.rs
@@ -106,13 +106,13 @@ extern crate from_file_derive;
 #[macro_use]
 extern crate failure;
 
-use futures::{future::Future, future::lazy, Stream, stream::iter_ok};
+use futures::{future::lazy, future::Future, stream::iter_ok, Stream};
 
-use crate::{
-    task::{as_future, Task},
-    task::TaskError,
-};
 use crate::condition::{Answer, Con, ConditionFuture};
+use crate::{
+    task::TaskError,
+    task::{as_future, Task},
+};
 
 #[doc(hidden)]
 pub mod cli;
@@ -163,8 +163,8 @@ pub mod util;
 #[doc(hidden)]
 pub mod zip_utils;
 
-pub mod versions;
 pub mod php;
+pub mod versions;
 
 #[doc(hidden)]
 pub struct WF2;

--- a/wf2_core/src/lib.rs
+++ b/wf2_core/src/lib.rs
@@ -106,6 +106,14 @@ extern crate from_file_derive;
 #[macro_use]
 extern crate failure;
 
+use futures::{future::Future, future::lazy, Stream, stream::iter_ok};
+
+use crate::{
+    task::{as_future, Task},
+    task::TaskError,
+};
+use crate::condition::{Answer, Con, ConditionFuture};
+
 #[doc(hidden)]
 pub mod cli;
 #[doc(hidden)]
@@ -138,7 +146,6 @@ pub mod output;
 #[doc(hidden)]
 pub mod output_files;
 #[doc(hidden)]
-pub mod php;
 pub mod recipes;
 #[doc(hidden)]
 pub mod scripts;
@@ -156,14 +163,8 @@ pub mod util;
 #[doc(hidden)]
 pub mod zip_utils;
 
-use futures::{future::lazy, future::Future, stream::iter_ok, Stream};
-
-use crate::{
-    task::TaskError,
-    task::{as_future, Task},
-};
-
-use crate::condition::{Answer, Con, ConditionFuture};
+pub mod versions;
+pub mod php;
 
 #[doc(hidden)]
 pub struct WF2;

--- a/wf2_core/src/services/elastic_search.rs
+++ b/wf2_core/src/services/elastic_search.rs
@@ -14,9 +14,8 @@ impl Service for ElasticSearchService {
     const NAME: &'static str = "elasticsearch";
     const IMAGE: &'static str = "wearejh/elasticsearch:7.6-m2";
 
-
     fn dc_service(&self, ctx: &Context, _: &()) -> DcService {
-        let image = format!("wearejh/elasticsearch:{}-m2",ctx.es_version.get_image());
+        let image = format!("wearejh/elasticsearch:{}-m2", ctx.es_version.get_image());
         DcService::new(ctx.name(), Self::NAME, image)
             .set_ports(vec!["9200:9200"])
             .set_volumes(vec![format!(

--- a/wf2_core/src/services/elastic_search.rs
+++ b/wf2_core/src/services/elastic_search.rs
@@ -14,8 +14,10 @@ impl Service for ElasticSearchService {
     const NAME: &'static str = "elasticsearch";
     const IMAGE: &'static str = "wearejh/elasticsearch:7.6-m2";
 
+
     fn dc_service(&self, ctx: &Context, _: &()) -> DcService {
-        DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
+        let image = format!("wearejh/elasticsearch:{}-m2",ctx.es_version.get_image());
+        DcService::new(ctx.name(), Self::NAME, image)
             .set_ports(vec!["9200:9200"])
             .set_volumes(vec![format!(
                 "{}:{}",

--- a/wf2_core/src/versions/elasticsearch.rs
+++ b/wf2_core/src/versions/elasticsearch.rs
@@ -2,7 +2,6 @@ use serde::de;
 use std::fmt;
 use std::fmt::Formatter;
 
-
 //TODO: Refactor to make more generic, so we can use for php versions too.
 macro_rules! build_es_version {
 ($default:ident,[$( $key:ident => $value:expr ),*]) => {

--- a/wf2_core/src/versions/elasticsearch.rs
+++ b/wf2_core/src/versions/elasticsearch.rs
@@ -1,0 +1,70 @@
+use serde::de;
+use std::fmt;
+use std::fmt::Formatter;
+
+
+//TODO: Refactor to make more generic, so we can use for php versions too.
+macro_rules! build_es_version {
+($default:ident,[$( $key:ident => $value:expr ),*]) => {
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum ELASTICSEARCH {
+    $($key,)*
+    }
+    impl ELASTICSEARCH {
+    pub fn get_image(&self) -> f64 {
+        match self {
+            $(
+                ELASTICSEARCH::$key => $value,
+            )*
+        }
+    }
+    }
+
+    impl Default for ELASTICSEARCH {
+        fn default() -> Self {
+            ELASTICSEARCH::$default
+        }
+    }
+
+
+    impl std::fmt::Display for ELASTICSEARCH {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self)
+        }
+    }
+
+    pub fn deserialize_elasticsearch<'de, D>(deserializer: D) -> Result<ELASTICSEARCH, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ELASTICSEARCHVisitor;
+
+        impl<'de> de::Visitor<'de> for ELASTICSEARCHVisitor {
+            type Value = ELASTICSEARCH;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                let versions = vec![$($value.to_string(),)*].iter().map(|val| format!("`{}`",val)).collect::<Vec<String>>().join(", ");
+                formatter.write_fmt(format_args!("either {}",versions))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let versions = vec![$($value.to_string(),)*].join(", ");
+                let r = match v {
+                    $(num if num == $value => Ok(ELASTICSEARCH::$key),)*
+                        _ => Err(format!("expected versions: {}",versions)),
+                };
+                r.map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_any(ELASTICSEARCHVisitor)
+    }
+
+
+}
+
+}
+build_es_version!(SevenSix,[SixEight => 6.8,SevenSix => 7.6]);

--- a/wf2_core/src/versions/mod.rs
+++ b/wf2_core/src/versions/mod.rs
@@ -1,0 +1,1 @@
+pub mod elasticsearch;


### PR DESCRIPTION
Makes code more generic in order to add support for multiple elasticsearch versions.

- Uses fixed rust version, instead of always using latest and greatest.

Currently supported:
- 6.8 (elasticsearch ver: 6.8.14)
- 7.6 (elasticsearch ver: 7.6.2)