### PR TITLE
Selinux support

### DIFF
--- a/wf2_core/src/dc_service.rs
+++ b/wf2_core/src/dc_service.rs
@@ -49,6 +49,9 @@ pub struct DcService {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<HashMap<String, DcServiceNetwork>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub privileged: Option<bool>,
 }
 
 impl DcService {
@@ -154,6 +157,11 @@ impl DcService {
             self.networks = Some(hm)
         }
         self
+    }
+    pub fn set_privileged(&mut self, privileged: bool) -> &mut Self {
+        self.privileged = Some(privileged);
+        self
+
     }
     pub fn finish(&self) -> DcService {
         DcService { ..self.clone() }

--- a/wf2_core/src/recipes/m2/services/db.rs
+++ b/wf2_core/src/recipes/m2/services/db.rs
@@ -60,14 +60,14 @@ impl Service<M2Vars> for DbService {
         let opts = DbServiceOptions::from_ctx(&ctx);
         DcService::new(ctx.name(), Self::NAME, opts.image)
             .set_volumes(vec![
-                format!("{}:{}", M2Volumes::DB, DbService::VOLUME_DATA),
+                format!("{}:{}:z", M2Volumes::DB, DbService::VOLUME_DATA),
                 format!(
-                    "{}:{}",
+                    "{}:{}:z",
                     vars.content[&M2Var::DbConfDir],
                     DbService::VOLUME_CONF
                 ),
                 format!(
-                    "{}:{}",
+                    "{}:{}:z",
                     vars.content[&M2Var::DbInitDir],
                     DbService::VOLUME_ENTRY
                 ),

--- a/wf2_core/src/recipes/m2/services/nginx.rs
+++ b/wf2_core/src/recipes/m2/services/nginx.rs
@@ -20,8 +20,8 @@ impl Service<M2Vars> for M2NginxService {
             .dc_service(&ctx, &())
             .set_working_dir(M2_ROOT)
             .set_volumes(vec![
-                format!("{}:{}", M2Volumes::APP, M2_ROOT),
-                format!("{}:/etc/nginx/conf.d", vars.content[&M2Var::NginxDir]),
+                format!("{}:{}:z", M2Volumes::APP, M2_ROOT),
+                format!("{}:/etc/nginx/conf.d:z", vars.content[&M2Var::NginxDir]),
             ])
             .set_depends_on(vec![PhpService::NAME])
             .set_env_file(vec![vars.content[&M2Var::EnvFile].to_string()])

--- a/wf2_core/src/recipes/m2/services/node.rs
+++ b/wf2_core/src/recipes/m2/services/node.rs
@@ -18,7 +18,7 @@ impl Service<M2Vars> for M2NodeService {
             .dc_service(ctx, &())
             .set_working_dir(M2_ROOT)
             .set_init(true)
-            .set_volumes(vec![format!("{}:{}", M2Volumes::APP, M2_ROOT)])
+            .set_volumes(vec![format!("{}:{}:z", M2Volumes::APP, M2_ROOT)])
             .set_env_file(vec![vars.content[&M2Var::EnvFile].to_string()])
             .finish()
     }

--- a/wf2_core/src/recipes/m2/services/php.rs
+++ b/wf2_core/src/recipes/m2/services/php.rs
@@ -39,7 +39,7 @@ impl Service<M2Vars> for PhpService {
         let image = &vars.content[&M2Var::PhpImage].clone();
         DcService::new(ctx.name(), Self::NAME, image)
             .set_volumes(vec![
-                format!("{}:{}", M2Volumes::APP, M2_ROOT),
+                format!("{}:{}:z", M2Volumes::APP, M2_ROOT),
                 format!(
                     "{}:{}",
                     M2Volumes::COMPOSER_CACHE,

--- a/wf2_core/src/recipes/m2/services/php.rs
+++ b/wf2_core/src/recipes/m2/services/php.rs
@@ -41,7 +41,7 @@ impl Service<M2Vars> for PhpService {
             .set_volumes(vec![
                 format!("{}:{}:z", M2Volumes::APP, M2_ROOT),
                 format!(
-                    "{}:{}",
+                    "{}:{}:z",
                     M2Volumes::COMPOSER_CACHE,
                     PhpService::COMPOSER_CACHE_PATH,
                 ),

--- a/wf2_core/src/recipes/m2/services/unison.rs
+++ b/wf2_core/src/recipes/m2/services/unison.rs
@@ -26,11 +26,11 @@ impl Service<M2Vars> for UnisonService {
         DcService::new(ctx.name(), Self::NAME, Self::IMAGE)
             .set_volumes(vec![
                 format!(
-                    "{}:{}",
+                    "{}:{}:z",
                     vars.content[&M2Var::Pwd],
                     UnisonService::VOLUME_HOST
                 ),
-                format!("{}:{}", M2Volumes::APP, UnisonService::VOLUME_INTERNAL),
+                format!("{}:{}:z", M2Volumes::APP, UnisonService::VOLUME_INTERNAL),
                 format!(
                     "{}:{}",
                     vars.content[&M2Var::UnisonFile],

--- a/wf2_core/src/recipes/m2/services/unison.rs
+++ b/wf2_core/src/recipes/m2/services/unison.rs
@@ -32,7 +32,7 @@ impl Service<M2Vars> for UnisonService {
                 ),
                 format!("{}:{}:z", M2Volumes::APP, UnisonService::VOLUME_INTERNAL),
                 format!(
-                    "{}:{}",
+                    "{}:{}:z",
                     vars.content[&M2Var::UnisonFile],
                     UnisonService::CONFIG_FILE
                 ),

--- a/wf2_core/src/services/traefik.rs
+++ b/wf2_core/src/services/traefik.rs
@@ -52,6 +52,7 @@ impl Service for TraefikService {
                 "default",
                 DcServiceNetwork::with_aliases(ctx.domains.clone()),
             )
+            .set_privileged(true)
             .finish()
     }
 }


### PR DESCRIPTION
**Background**

WF2 doesn't run when using wf2 with selinux enabled.

**Functionality**

This PR adds support for selinux by doing the following 

- Modifying the traefik service to use the privileged flag, which allows traefik to connect to docker, which would normally be blocked by selinux.
- Modifying volumes with the `z` flag which will automatically modifying the selinux labels of the paths it is added to.
