### PR TITLE
Use fixed rust version in ci

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Toolchain
               uses: actions-rs/toolchain@v1
               with:
-                  toolchain: 1.52.0
+                  toolchain: 1.50.0
                   target: x86_64-apple-darwin
                   override: true
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ jobs:
             - name: Toolchain
               uses: actions-rs/toolchain@v1
               with:
-                  toolchain: stable
+                  toolchain: 1.52.0
                   target: x86_64-apple-darwin
                   override: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.52.0
           override: true
 
       - name: Run cargo check
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.52.0
           override: true
 
       - name: Run cargo test
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.52.0
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.0
+          toolchain: 1.50.0
           override: true
 
       - name: Run cargo check
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.0
+          toolchain: 1.50.0
           override: true
 
       - name: Run cargo test
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.52.0
+          toolchain: 1.50.0
           override: true
           components: rustfmt, clippy
 

--- a/wf2_core/src/scripts/script.rs
+++ b/wf2_core/src/scripts/script.rs
@@ -74,9 +74,12 @@ impl Script {
 
     pub fn has_dc_tasks(steps: &[ScriptItem]) -> bool {
         steps.iter().any(|step| {
-            matches!(step, ScriptItem::DcRunCommand { .. }
-            | ScriptItem::DcExecCommand { .. }
-            | ScriptItem::DcPassThru { .. })
+            matches!(
+                step,
+                ScriptItem::DcRunCommand { .. }
+                    | ScriptItem::DcExecCommand { .. }
+                    | ScriptItem::DcPassThru { .. }
+            )
         })
     }
 


### PR DESCRIPTION
**Background**

Currently builds will fail because formatting has changed recently and since CI doesn't use a fixed version, meaning this can change at anytime.

**Functionality**

- Fix CI rust version to `1.50.0`
- Runs cargo fmt.