### PR TITLE
Add Elasticsearch runtime env variables

### DIFF
--- a/wf2_core/src/recipes/m2/output_files/m2_runtime_env_file.rs
+++ b/wf2_core/src/recipes/m2/output_files/m2_runtime_env_file.rs
@@ -85,6 +85,7 @@ env_vars! {
     BLACKFIRE_SERVER_ID=""
     BLACKFIRE_SERVER_TOKEN=""
     NODE_TLS_REJECT_UNAUTHORIZED="0"
+    ELASTICSEARCH_HOST="elasticsearch"
 }
 
 //


### PR DESCRIPTION
Elasticsearch is required for M2.4 so it's required to run integration tests as well. I added an environment variable for it so that ES host can always be resolved based on environment vars, both locally and in CI.